### PR TITLE
WIP: Tried to add multiple arguments to options

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -99,7 +99,7 @@ export abstract class Command {
    * @returns The value of the option in the command line or undefined if the
    * option does not exist.
    */
-  public option(optionName: string): string | boolean | undefined {
+  public option(optionName: string): string[] | boolean | undefined {
     const optionObject = this.options_map.get(optionName);
 
     if (optionObject) {
@@ -197,6 +197,6 @@ export abstract class Command {
     );
 
     // Combine all the errors and remove any duplicates
-    return [...new Set(optionsErrors.concat(argsErrors))].sort();
+    return [...new Set(optionsErrors!.concat(argsErrors) ?? null)].sort();
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -44,10 +44,11 @@ export interface IOption {
   /** Does this option take in a value? */
   // deno-lint-ignore camelcase
   takes_value: boolean;
+  arg_count: number;
   /**
    * The option's value. Initially set to `false` and set to `true` if provided
    * through the command line. Value is the provided value through the command
    * line if this option takes in a value.
    */
-  value?: boolean | string;
+  value?: boolean | string[];
 }


### PR DESCRIPTION
Closes #15

## So far the following greet.ts appears to work

```
import * as Line from "./mod.ts";

class GreetMainCommand extends Line.MainCommand {
  public signature = "greet [greeting] [name]"

  public arguments = {
    "greeting": "The greeting before the name.",
    "name": "The name of the thing to greet.",
  };

  public options = {
    "--some-option [arg_1] [arg_2]": "description",
  };

  public handle(): void {
    const someOption = this.option("--some-option");

    if (someOption) {
      console.log(`someOption: ${someOption}`);
    }

    const greeting = this.argument("greeting");
    const name = this.argument("name");

    console.log(`${greeting}, ${name}!`);
  }
}

const cli = new Line.CLI({
  name: "Greeter CLI",
  description: "A CLI that outputs greets",
  version: "v1.0.0",
  command: GreetMainCommand,
});

cli.run();
```

```
> deno run greet.ts --some-option 3 4 hello world
[debug output]
someOption: 3,4
hello, world
```

Changes not final and tests need to be written. It might be better to use regexes here. 