### PR TITLE
chore: unify drashland readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Line
 
 [![Latest Release](https://img.shields.io/github/release/drashland/line.svg?color=bright_green&label=latest)](https://github.com/drashland/line/releases/latest)
-[![CI - Main](https://img.shields.io/github/workflow/status/drashland/line/Master/main?label=ci%20-%20main)](https://github.com/drashland/line/actions/workflows/master.yml)
+[![CI](https://img.shields.io/github/workflow/status/drashland/line/Master?label=ci)](https://github.com/drashland/line/actions/workflows/master.yml)
 
-<img align="right" src="./logo.svg" alt="Drash Land - Line logo" width="150" style="max-width: 150px">
+<img align="right" src="./logo.svg" alt="Drash Land - Line logo" height="150" style="max-height: 150px">
 
 Line is a class-based, command-line interface (CLI) framework for Deno.
 


### PR DESCRIPTION
Unifies the README file across the major drashland projects